### PR TITLE
Upgraded SPFx to 1.21.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ cd spfx-copilot-dashboard
 npm install
 ```
 
+> [!IMPORTANT]
+> Since the current used version of SPFx is a pre-release version, you need to perform a workaround to use `fast-serve`. A small guide can be found here: [Fast-Serve with SPFx pre-release version](SPFx%20fast%20serve%20with%20pre-release%20version.md).
+
 ### Build the Solution
 ```bash
 gulp build
@@ -58,6 +61,13 @@ gulp build
 ```bash
 gulp serve
 ```
+
+If you prefer using fast-serve, you can run the following command:
+
+```bash
+npm run serve
+```
+
 > Open **https://your-sharepoint-site/_layouts/15/workbench.aspx** to test locally.
 
 ### Deploy to SharePoint
@@ -81,7 +91,7 @@ gulp serve
 
 ## 🔧 Technologies Used
 
-![version](https://img.shields.io/badge/version-1.20.0-green.svg)
+![version](https://img.shields.io/badge/version-1.21.0_preview-green.svg)
 
 - **SharePoint Framework (SPFx)**
 - **React**

--- a/SPFx fast serve with pre-release version.md
+++ b/SPFx fast serve with pre-release version.md
@@ -1,0 +1,27 @@
+# Fast-Serve with SPFx pre-release version
+
+> [!IMPORTANT]
+> The solution uses a pre-release version of SPFx. Since it's not yet fully supported by the fast-serve package, you might encounter some issues.
+
+At the time of writing, there is no version of the `spfx-fast-serve-helpers` package that corresponds to the preview version of SPFx `1.21.0-beta.0`.
+
+Since there is not a correct version for the SPFx preview version there are some steps that need to be performed in order to trick the fast-serve command and run the pre-release version of SPFx.
+
+## Install the necessary packages:
+
+```bash
+npm install
+
+spfx-fast-serve
+```
+
+This updates to the latest version of `spfx-fast-serve-helpers` to `~1.21.0-beta.0`, which isn't available yet.
+  
+  > [!IMPORTANT]
+  > To avoid any issue regarding the mismatching version of the fast-serve package you should avoid installing the dependencies from the spfx-fast-serve command.
+
+## Run the serve command:
+
+```bash
+npm run serve
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.0.1",
       "dependencies": {
         "@fluentui/react": "^8.106.4",
-        "@microsoft/sp-component-base": "1.20.0",
-        "@microsoft/sp-core-library": "1.20.0",
-        "@microsoft/sp-lodash-subset": "1.20.0",
-        "@microsoft/sp-office-ui-fabric-core": "1.20.0",
-        "@microsoft/sp-property-pane": "1.20.0",
-        "@microsoft/sp-webpart-base": "1.20.0",
+        "@microsoft/sp-component-base": "1.21.0-beta.0",
+        "@microsoft/sp-core-library": "1.21.0-beta.0",
+        "@microsoft/sp-lodash-subset": "1.21.0-beta.0",
+        "@microsoft/sp-office-ui-fabric-core": "1.21.0-beta.0",
+        "@microsoft/sp-property-pane": "1.21.0-beta.0",
+        "@microsoft/sp-webpart-base": "1.21.0-beta.0",
         "@pnp/graph": "^4.10.0",
         "@pnp/sp": "^4.10.0",
         "react": "17.0.1",
@@ -22,11 +22,11 @@
         "tslib": "2.3.1"
       },
       "devDependencies": {
-        "@microsoft/eslint-config-spfx": "1.20.2",
-        "@microsoft/eslint-plugin-spfx": "1.20.2",
+        "@microsoft/eslint-config-spfx": "1.21.0-beta.0",
+        "@microsoft/eslint-plugin-spfx": "1.21.0-beta.0",
         "@microsoft/rush-stack-compiler-4.7": "0.1.0",
-        "@microsoft/sp-build-web": "1.20.2",
-        "@microsoft/sp-module-interfaces": "1.20.2",
+        "@microsoft/sp-build-web": "1.21.0-beta.0",
+        "@microsoft/sp-module-interfaces": "1.21.0-beta.0",
         "@rushstack/eslint-config": "4.0.1",
         "@types/react": "17.0.45",
         "@types/react-dom": "17.0.17",
@@ -172,6 +172,38 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@azure/core-http-compat": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.2.0.tgz",
+      "integrity": "sha512-1kW8ZhN0CfbNOG6C688z5uh2yrzALE7dDXHiR9dY4vt+EbhGZQSbjDa5bQd2rf3X2pdWMsXbqbArxUyeNdvtmg==",
+      "dev": true,
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-client": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-http-compat/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-http-compat/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
     },
     "node_modules/@azure/core-http/node_modules/uuid": {
       "version": "8.3.2",
@@ -334,6 +366,25 @@
       }
     },
     "node_modules/@azure/core-util/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
+    },
+    "node_modules/@azure/core-xml": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.4.4.tgz",
+      "integrity": "sha512-J4FYAqakGXcbfeZjwjMzjNcpcH4E+JtEBv+xcV1yL0Ydn/6wbQfeFKTCHh9wttAi0lmajHw7yBbHPRG+YHckZQ==",
+      "dev": true,
+      "dependencies": {
+        "fast-xml-parser": "^4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-xml/node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
@@ -3228,6 +3279,30 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
     "node_modules/@jsonjoy.com/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
@@ -3370,13 +3445,13 @@
       }
     },
     "node_modules/@microsoft/eslint-config-spfx": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/eslint-config-spfx/-/eslint-config-spfx-1.20.2.tgz",
-      "integrity": "sha512-M3kCrwCcuchdni6SFWbJ1SqKcZYzK3Lig98/xCqVzcp4s3FCFcfziUaMA+TfktEuHuSry+n6WYKFrH7SnucePA==",
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/eslint-config-spfx/-/eslint-config-spfx-1.21.0-beta.0.tgz",
+      "integrity": "sha512-w7NL7kYC9KJ+NTGDQoJEOmjqGMxdtqb32L+M+WJqm3U79oyRo9iYCPzGWSwpuQKytGxbqYm3kOkn6BOH1res+Q==",
       "dev": true,
       "dependencies": {
-        "@microsoft/eslint-plugin-spfx": "1.20.2",
-        "@rushstack/eslint-config": "4.0.2",
+        "@microsoft/eslint-plugin-spfx": "1.21.0-beta.0",
+        "@rushstack/eslint-config": "4.1.1",
         "@typescript-eslint/utils": "8.1.0"
       },
       "engines": {
@@ -3386,13 +3461,31 @@
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/@microsoft/eslint-config-spfx/node_modules/@rushstack/eslint-config": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@rushstack/eslint-config/-/eslint-config-4.0.2.tgz",
-      "integrity": "sha512-RFLynEk5hiGjgzFKephENrBWZZfoQe+3e76Q78KXjeGsndbaZXDHy0OxLfZethlEutDQEDiE3vpkbJ1mfcMeGg==",
+    "node_modules/@microsoft/eslint-config-spfx/node_modules/@microsoft/tsdoc": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "dev": true
+    },
+    "node_modules/@microsoft/eslint-config-spfx/node_modules/@microsoft/tsdoc-config": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.17.1.tgz",
+      "integrity": "sha512-UtjIFe0C6oYgTnad4q1QP4qXwLhe6tIpNTRStJ2RZEPIkqQPREAwE5spzVxsdn9UaEMUqhh0AqSx3X4nWAKXWw==",
       "dev": true,
       "dependencies": {
-        "@rushstack/eslint-patch": "1.10.4",
+        "@microsoft/tsdoc": "0.15.1",
+        "ajv": "~8.12.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.2"
+      }
+    },
+    "node_modules/@microsoft/eslint-config-spfx/node_modules/@rushstack/eslint-config": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-config/-/eslint-config-4.1.1.tgz",
+      "integrity": "sha512-fVL6mGv2pFEe8t8FRu6rKYRHpTIYrbY/Iqc/xQTa4u4bp6V+Y47teSWn1FeApgKk5tr34KmWqLPjzyNKEOTCig==",
+      "dev": true,
+      "dependencies": {
+        "@rushstack/eslint-patch": "1.10.5",
         "@rushstack/eslint-plugin": "0.16.1",
         "@rushstack/eslint-plugin-packlets": "0.9.2",
         "@rushstack/eslint-plugin-security": "0.8.3",
@@ -3402,12 +3495,18 @@
         "@typescript-eslint/utils": "~8.1.0",
         "eslint-plugin-promise": "~6.1.1",
         "eslint-plugin-react": "~7.33.2",
-        "eslint-plugin-tsdoc": "~0.3.0"
+        "eslint-plugin-tsdoc": "~0.4.0"
       },
       "peerDependencies": {
         "eslint": "^8.57.0",
         "typescript": ">=4.7.0"
       }
+    },
+    "node_modules/@microsoft/eslint-config-spfx/node_modules/@rushstack/eslint-patch": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.5.tgz",
+      "integrity": "sha512-kkKUDVlII2DQiKy7UstOR1ErJP8kUKAQ4oa+SQtM0K+lPdmmjj0YnnxBgtTVYH7mUKtbsxeFC9y0AmK7Yb78/A==",
+      "dev": true
     },
     "node_modules/@microsoft/eslint-config-spfx/node_modules/@rushstack/eslint-plugin": {
       "version": "0.16.1",
@@ -3435,10 +3534,62 @@
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@microsoft/eslint-config-spfx/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@microsoft/eslint-config-spfx/node_modules/eslint-plugin-tsdoc": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.4.0.tgz",
+      "integrity": "sha512-MT/8b4aKLdDClnS8mP3R/JNjg29i0Oyqd/0ym6NnQf+gfKbJJ4ZcSh2Bs1H0YiUMTBwww5JwXGTWot/RwyJ7aQ==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/tsdoc": "0.15.1",
+        "@microsoft/tsdoc-config": "0.17.1"
+      }
+    },
+    "node_modules/@microsoft/eslint-config-spfx/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/@microsoft/eslint-config-spfx/node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/@microsoft/eslint-plugin-spfx": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/eslint-plugin-spfx/-/eslint-plugin-spfx-1.20.2.tgz",
-      "integrity": "sha512-GfBKb3Xm4n6qMezzU4A4kxZKIAMUUdTQvTCq5uhX96YxciR9Ao3SLu5CCW/hZasIlQHtIyqv6Aju1bRch2zSIw==",
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/eslint-plugin-spfx/-/eslint-plugin-spfx-1.21.0-beta.0.tgz",
+      "integrity": "sha512-ELdBwmyIWzQZ6SziF4yy2mzzzi68jBLZUeEIkawgWleSN0gmaQNfv08OyCGrxT5uI9XslN4zFonsIuV2WvZ0WQ==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "8.1.0"
@@ -3710,16 +3861,6 @@
         "string-argv": "~0.3.1"
       }
     },
-    "node_modules/@microsoft/rush-lib/node_modules/@types/node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
-      }
-    },
     "node_modules/@microsoft/rush-lib/node_modules/ajv": {
       "version": "8.13.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
@@ -3766,21 +3907,6 @@
         "node": ">=8.6.0"
       }
     },
-    "node_modules/@microsoft/rush-lib/node_modules/form-data": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.3.tgz",
-      "integrity": "sha512-q5YBMeWy6E2Un0nMGWMgI65MAKtaylxfNJGJxpGh45YDciZB4epbWpaAfImil6CPAPTYB4sh0URQNDRIZG5F2w==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@microsoft/rush-lib/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -3806,26 +3932,6 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@microsoft/rush-lib/node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/@microsoft/rush-lib/node_modules/resolve": {
@@ -3872,12 +3978,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@microsoft/rush-lib/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
-    },
     "node_modules/@microsoft/rush-lib/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -3885,22 +3985,6 @@
       "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@microsoft/rush-lib/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
-    },
-    "node_modules/@microsoft/rush-lib/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/@microsoft/rush-lib/node_modules/yallist": {
@@ -4379,31 +4463,989 @@
       }
     },
     "node_modules/@microsoft/sp-build-core-tasks": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-build-core-tasks/-/sp-build-core-tasks-1.20.2.tgz",
-      "integrity": "sha512-WHfKcTaengpxMXQ8pW+iOASjXbklU+twATYZJqOnSm17RGozYtovu1gdhc3+3SWN+JgD1r6Bh5dYaMCRI7ee9g==",
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-build-core-tasks/-/sp-build-core-tasks-1.21.0-beta.0.tgz",
+      "integrity": "sha512-ZGPzN1lmHmWRGhfSsLFmMYpqC3bpIp9KuqzICNCNBat4zsAWD18Dp8P0Nlr7Bz+vGlVU7j0kT3mZAffpwosNtA==",
       "dev": true,
       "dependencies": {
         "@microsoft/gulp-core-build": "3.19.0",
         "@microsoft/gulp-core-build-serve": "3.13.0",
         "@microsoft/gulp-core-build-webpack": "6.0.3",
-        "@microsoft/spfx-heft-plugins": "1.20.2",
-        "@rushstack/node-core-library": "5.9.0",
-        "@rushstack/terminal": "0.14.2",
+        "@microsoft/spfx-heft-plugins": "1.21.0-beta.0",
+        "@rushstack/node-core-library": "5.10.2",
+        "@rushstack/terminal": "0.14.5",
         "@types/lodash": "4.14.117",
         "colors": "~1.2.1",
         "gulp": "4.0.2",
         "lodash": "4.17.21",
-        "webpack": "~5.88.1"
+        "webpack": "~5.95.0"
       },
       "engines": {
         "node": ">=18.17.1 <19.0.0"
       }
     },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@azure/core-tracing": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.2.0.tgz",
+      "integrity": "sha512-UKTiEJPkWcESPYJz3X5uKRYyOcJD+4nYph+KpfdPRnQJVrZfk0KJgdnaAWKfhsBBtAf/D58Az4AvCJEmWgIBAg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@azure/identity": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.5.0.tgz",
+      "integrity": "sha512-EknvVmtBuSIic47xkOqyNabAme0RYTw52BTMz8eBgU1ysTyMrD1uOoM+JdS0J/4Yfp98IBT3osqq3BfwSaNaGQ==",
+      "dev": true,
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^3.26.1",
+        "@azure/msal-node": "^2.15.0",
+        "events": "^3.0.0",
+        "jws": "^4.0.0",
+        "open": "^8.0.0",
+        "stoppable": "^1.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@azure/storage-blob": {
+      "version": "12.26.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.26.0.tgz",
+      "integrity": "sha512-SriLPKezypIsiZ+TtlFfE46uuBIap2HeaQVS78e1P7rz5OSbq0rsd52WE1mC5f7vAeLiXqv7I7oRhL3WFZEw3Q==",
+      "dev": true,
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.4.0",
+        "@azure/core-client": "^1.6.2",
+        "@azure/core-http-compat": "^2.0.0",
+        "@azure/core-lro": "^2.2.0",
+        "@azure/core-paging": "^1.1.1",
+        "@azure/core-rest-pipeline": "^1.10.1",
+        "@azure/core-tracing": "^1.1.2",
+        "@azure/core-util": "^1.6.1",
+        "@azure/core-xml": "^1.4.3",
+        "@azure/logger": "^1.0.0",
+        "events": "^3.0.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/load-themed-styles": {
+      "version": "2.0.156",
+      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-2.0.156.tgz",
+      "integrity": "sha512-opA5igpT+RrzpO4kIYsTeyLDIKmHCBNFxHbZc1C5JYA1jEFJi0jSjxu/hVgbcSCRLzKlLg+uKF+vLYkBOeWoSA==",
+      "dev": true
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/rush-lib": {
+      "version": "5.148.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/rush-lib/-/rush-lib-5.148.0.tgz",
+      "integrity": "sha512-+NXU/Lds91BjFHadOU9ars55+Ptv2cv/yvUdqAh7eMXhtAHF7O8KiXMMeeUN/C/sYGNqgd/q9v8huomcxo4yOg==",
+      "dev": true,
+      "dependencies": {
+        "@pnpm/dependency-path": "~5.1.7",
+        "@pnpm/dependency-path-lockfile-pre-v9": "npm:@pnpm/dependency-path@~2.1.2",
+        "@pnpm/link-bins": "~5.3.7",
+        "@rushstack/heft-config-file": "0.16.3",
+        "@rushstack/lookup-by-path": "0.5.2",
+        "@rushstack/node-core-library": "5.10.2",
+        "@rushstack/package-deps-hash": "4.3.3",
+        "@rushstack/package-extractor": "0.10.7",
+        "@rushstack/rig-package": "0.5.3",
+        "@rushstack/rush-amazon-s3-build-cache-plugin": "5.148.0",
+        "@rushstack/rush-azure-storage-build-cache-plugin": "5.148.0",
+        "@rushstack/rush-http-build-cache-plugin": "5.148.0",
+        "@rushstack/stream-collator": "4.1.81",
+        "@rushstack/terminal": "0.14.5",
+        "@rushstack/ts-command-line": "4.23.3",
+        "@yarnpkg/lockfile": "~1.0.2",
+        "builtin-modules": "~3.1.0",
+        "cli-table": "~0.3.1",
+        "dependency-path": "~9.2.8",
+        "fast-glob": "~3.3.1",
+        "figures": "3.0.0",
+        "git-repo-info": "~2.1.0",
+        "glob-escape": "~0.0.2",
+        "https-proxy-agent": "~5.0.0",
+        "ignore": "~5.1.6",
+        "inquirer": "~7.3.3",
+        "js-yaml": "~3.13.1",
+        "npm-check": "~6.0.1",
+        "npm-package-arg": "~6.1.0",
+        "pnpm-sync-lib": "0.2.9",
+        "read-package-tree": "~5.1.5",
+        "rxjs": "~6.6.7",
+        "semver": "~7.5.4",
+        "ssri": "~8.0.0",
+        "strict-uri-encode": "~2.0.0",
+        "tapable": "2.2.1",
+        "tar": "~6.2.1",
+        "true-case-path": "~2.2.1",
+        "uuid": "~8.3.2"
+      },
+      "engines": {
+        "node": ">=5.6.0"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/rush-lib/node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/rush-lib/node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/rush-lib/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader": {
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-css-loader/-/sp-css-loader-1.21.0-beta.0.tgz",
+      "integrity": "sha512-4KmhtoU75Y+s4ckrAoLLL1dUhDc6UmapOvV7e5+/jCmBTeAGi5iHEd/a/aV2iFCaD8e3M8Tf3H886f7NRDmjYA==",
+      "dev": true,
+      "dependencies": {
+        "@microsoft/load-themed-styles": "2.0.156",
+        "@rushstack/node-core-library": "5.10.2",
+        "autoprefixer": "9.7.1",
+        "css-loader": "3.4.2",
+        "cssnano": "~5.1.14",
+        "loader-utils": "~3.2.1",
+        "postcss": "^8.4.19",
+        "postcss-modules-extract-imports": "~3.0.0",
+        "postcss-modules-local-by-default": "~4.0.0",
+        "postcss-modules-scope": "~3.0.0",
+        "postcss-modules-values": "~4.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^5.88.1"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/css-declaration-sorter": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz",
+      "integrity": "sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/cssnano": {
+      "version": "5.1.15",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.15.tgz",
+      "integrity": "sha512-j+BKgDcLDQA+eDifLx0EO4XSA56b7uut3BQFH+wbSaSTuGLuiyTa/wbRYthUXX8LC9mLg+WWKe8h+qJuwTAbHw==",
+      "dev": true,
+      "dependencies": {
+        "cssnano-preset-default": "^5.2.14",
+        "lilconfig": "^2.0.3",
+        "yaml": "^1.10.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/cssnano"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/cssnano-preset-default": {
+      "version": "5.2.14",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.14.tgz",
+      "integrity": "sha512-t0SFesj/ZV2OTylqQVOrFgEh5uanxbO6ZAdeCrNsUQ6fVuXwYTxJPNAGvGTxHbD68ldIJNec7PyYZDBrfDQ+6A==",
+      "dev": true,
+      "dependencies": {
+        "css-declaration-sorter": "^6.3.1",
+        "cssnano-utils": "^3.1.0",
+        "postcss-calc": "^8.2.3",
+        "postcss-colormin": "^5.3.1",
+        "postcss-convert-values": "^5.1.3",
+        "postcss-discard-comments": "^5.1.2",
+        "postcss-discard-duplicates": "^5.1.0",
+        "postcss-discard-empty": "^5.1.1",
+        "postcss-discard-overridden": "^5.1.0",
+        "postcss-merge-longhand": "^5.1.7",
+        "postcss-merge-rules": "^5.1.4",
+        "postcss-minify-font-values": "^5.1.0",
+        "postcss-minify-gradients": "^5.1.1",
+        "postcss-minify-params": "^5.1.4",
+        "postcss-minify-selectors": "^5.2.1",
+        "postcss-normalize-charset": "^5.1.0",
+        "postcss-normalize-display-values": "^5.1.0",
+        "postcss-normalize-positions": "^5.1.1",
+        "postcss-normalize-repeat-style": "^5.1.1",
+        "postcss-normalize-string": "^5.1.0",
+        "postcss-normalize-timing-functions": "^5.1.0",
+        "postcss-normalize-unicode": "^5.1.1",
+        "postcss-normalize-url": "^5.1.0",
+        "postcss-normalize-whitespace": "^5.1.1",
+        "postcss-ordered-values": "^5.1.3",
+        "postcss-reduce-initial": "^5.1.2",
+        "postcss-reduce-transforms": "^5.1.0",
+        "postcss-svgo": "^5.1.0",
+        "postcss-unique-selectors": "^5.1.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/cssnano-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
+      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/icss-utils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.8",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-calc": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.2.4.tgz",
+      "integrity": "sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.9",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.2"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-colormin": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.1.tgz",
+      "integrity": "sha512-UsWQG0AqTFQmpBegeLLc1+c3jIqBNB0zlDGRWR+dQ3pRKJL1oeMzyqmH3o2PIfn9MBdNrVPWhDbT769LxCTLJQ==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.21.4",
+        "caniuse-api": "^3.0.0",
+        "colord": "^2.9.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-convert-values": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.3.tgz",
+      "integrity": "sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.21.4",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-discard-comments": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
+      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-discard-duplicates": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
+      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-discard-empty": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
+      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-discard-overridden": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
+      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-merge-longhand": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.7.tgz",
+      "integrity": "sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0",
+        "stylehacks": "^5.1.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-merge-rules": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.4.tgz",
+      "integrity": "sha512-0R2IuYpgU93y9lhVbO/OylTtKMVcHb67zjWIfCiKR9rWL3GUk1677LAqD/BcHizukdZEjT8Ru3oHRoAYoJy44g==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.21.4",
+        "caniuse-api": "^3.0.0",
+        "cssnano-utils": "^3.1.0",
+        "postcss-selector-parser": "^6.0.5"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-minify-font-values": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.1.0.tgz",
+      "integrity": "sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-minify-gradients": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.1.1.tgz",
+      "integrity": "sha512-VGvXMTpCEo4qHTNSa9A0a3D+dxGFZCYwR6Jokk+/3oB6flu2/PnPXAh2x7x52EkY5xlIHLm+Le8tJxe/7TNhzw==",
+      "dev": true,
+      "dependencies": {
+        "colord": "^2.9.1",
+        "cssnano-utils": "^3.1.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-minify-params": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.4.tgz",
+      "integrity": "sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.21.4",
+        "cssnano-utils": "^3.1.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-minify-selectors": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.2.1.tgz",
+      "integrity": "sha512-nPJu7OjZJTsVUmPdm2TcaiohIwxP+v8ha9NehQ2ye9szv4orirRU3SDdtUmKH+10nzn0bAyOXZ0UEr7OpvLehg==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.5"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-modules-extract-imports": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
+      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-modules-local-by-default": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.5.tgz",
+      "integrity": "sha512-6MieY7sIfTK0hYfafw1OMEG+2bg8Q1ocHCpoWLqOKj3JXlKu4G7btkmM/B7lFubYkYWmRSPLZi5chid63ZaZYw==",
+      "dev": true,
+      "dependencies": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-modules-scope": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+      "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.4"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-modules-values": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+      "dev": true,
+      "dependencies": {
+        "icss-utils": "^5.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-normalize-charset": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
+      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-normalize-display-values": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.1.0.tgz",
+      "integrity": "sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-normalize-positions": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.1.1.tgz",
+      "integrity": "sha512-6UpCb0G4eofTCQLFVuI3EVNZzBNPiIKcA1AKVka+31fTVySphr3VUgAIULBhxZkKgwLImhzMR2Bw1ORK+37INg==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-normalize-repeat-style": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.1.tgz",
+      "integrity": "sha512-mFpLspGWkQtBcWIRFLmewo8aC3ImN2i/J3v8YCFUwDnPu3Xz4rLohDO26lGjwNsQxB3YF0KKRwspGzE2JEuS0g==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-normalize-string": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.1.0.tgz",
+      "integrity": "sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-normalize-timing-functions": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.1.0.tgz",
+      "integrity": "sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-normalize-unicode": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.1.tgz",
+      "integrity": "sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.21.4",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-normalize-url": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.1.0.tgz",
+      "integrity": "sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==",
+      "dev": true,
+      "dependencies": {
+        "normalize-url": "^6.0.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-normalize-whitespace": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.1.1.tgz",
+      "integrity": "sha512-83ZJ4t3NUDETIHTa3uEg6asWjSBYL5EdkVB0sDncx9ERzOKBVJIUeDO9RyA9Zwtig8El1d79HBp0JEi8wvGQnA==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-ordered-values": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.1.3.tgz",
+      "integrity": "sha512-9UO79VUhPwEkzbb3RNpqqghc6lcYej1aveQteWY+4POIwlqkYE21HKWaLDF6lWNuqCobEAyTovVhtI32Rbv2RQ==",
+      "dev": true,
+      "dependencies": {
+        "cssnano-utils": "^3.1.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-reduce-initial": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.2.tgz",
+      "integrity": "sha512-dE/y2XRaqAi6OvjzD22pjTUQ8eOfc6m/natGHgKFBK9DxFmIm69YmaRVQrGgFlEfc1HePIurY0TmDeROK05rIg==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.21.4",
+        "caniuse-api": "^3.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-reduce-transforms": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.1.0.tgz",
+      "integrity": "sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-svgo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.1.0.tgz",
+      "integrity": "sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0",
+        "svgo": "^2.7.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/postcss-unique-selectors": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.1.1.tgz",
+      "integrity": "sha512-5JiODlELrz8L2HwxfPnhOWZYWDxVHWL83ufOv84NrcgipI7TaeRsatAhK4Tr2/ZiYldpK/wBvw5BD3qfaK96GA==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.5"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/sp-css-loader/node_modules/stylehacks": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
+      "integrity": "sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.21.4",
+        "postcss-selector-parser": "^6.0.4"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@microsoft/spfx-heft-plugins": {
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/spfx-heft-plugins/-/spfx-heft-plugins-1.21.0-beta.0.tgz",
+      "integrity": "sha512-jJCU54pruFIqPwz1wuFWTrGpFJkyotGBjl8/eBSe03/kSBWI2XiRMvLn0W5DSOCfezk80hgZTYvpwev2DltxEw==",
+      "dev": true,
+      "dependencies": {
+        "@azure/storage-blob": "~12.26.0",
+        "@microsoft/rush-lib": "5.148.0",
+        "@microsoft/sp-css-loader": "1.21.0-beta.0",
+        "@microsoft/sp-module-interfaces": "1.21.0-beta.0",
+        "@rushstack/heft-config-file": "0.16.3",
+        "@rushstack/localization-utilities": "0.12.17",
+        "@rushstack/module-minifier": "0.7.0",
+        "@rushstack/node-core-library": "5.10.2",
+        "@rushstack/rig-package": "0.5.3",
+        "@rushstack/set-webpack-public-path-plugin": "5.1.64",
+        "@rushstack/terminal": "0.14.5",
+        "@rushstack/webpack5-localization-plugin": "0.11.24",
+        "@rushstack/webpack5-module-minifier-plugin": "5.5.84",
+        "@types/tapable": "1.0.6",
+        "cors": "2.8.5",
+        "express": "4.18.1",
+        "fast-glob": "~3.2.12",
+        "git-repo-info": "~2.1.1",
+        "html-loader": "~4.2.0",
+        "jszip": "~3.8.0",
+        "lodash": "4.17.21",
+        "mime": "2.5.2",
+        "resolve": "~1.17.0",
+        "source-map": "0.6.1",
+        "source-map-loader": "~4.0.1",
+        "tapable": "1.1.3",
+        "uuid": "^9.0.0",
+        "webpack": "~5.95.0",
+        "xml": "~1.0.1"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@pnpm/crypto.base32-hash": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@pnpm/crypto.base32-hash/-/crypto.base32-hash-3.0.1.tgz",
+      "integrity": "sha512-DM4RR/tvB7tMb2FekL0Q97A5PCXNyEC+6ht8SaufAUFSJNxeozqHw9PHTZR03mzjziPzNQLOld0pNINBX3srtw==",
+      "dev": true,
+      "dependencies": {
+        "@pnpm/crypto.polyfill": "1.0.0",
+        "rfc4648": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=18.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@pnpm/dependency-path": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/@pnpm/dependency-path/-/dependency-path-5.1.7.tgz",
+      "integrity": "sha512-MKCyaTy1r9fhBXAnhDZNBVgo6ThPnicwJEG203FDp7pGhD7NruS/FhBI+uMd7GNsK3D7aIFCDAgbWpNTXn/eWw==",
+      "dev": true,
+      "dependencies": {
+        "@pnpm/crypto.base32-hash": "3.0.1",
+        "@pnpm/types": "12.2.0",
+        "semver": "^7.6.2"
+      },
+      "engines": {
+        "node": ">=18.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@pnpm/dependency-path/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@pnpm/types": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/types/-/types-12.2.0.tgz",
+      "integrity": "sha512-5RtwWhX39j89/Tmyv2QSlpiNjErA357T/8r1Dkg+2lD3P7RuS7Xi2tChvmOC3VlezEFNcWnEGCOeKoGRkDuqFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/heft-config-file": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/heft-config-file/-/heft-config-file-0.16.3.tgz",
+      "integrity": "sha512-fyk/amla4g9kuCh52Bj0EAM9n6tfLr9Y0AyCKFwlbXyKUtfbgN1BajxkBxHi3agRINp9TlF87zdL3Ceii5ZUpw==",
+      "dev": true,
+      "dependencies": {
+        "@rushstack/node-core-library": "5.10.2",
+        "@rushstack/rig-package": "0.5.3",
+        "@rushstack/terminal": "0.14.5",
+        "jsonpath-plus": "~10.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/localization-utilities": {
+      "version": "0.12.17",
+      "resolved": "https://registry.npmjs.org/@rushstack/localization-utilities/-/localization-utilities-0.12.17.tgz",
+      "integrity": "sha512-5pu+p9b7L4iQZDvBUdKTmMRSJw0k2F3pD/eqU0zZth3birpXS5/73ocKHeXHbERZFW5w1HeTE/Y/TQGDp0gC2g==",
+      "dev": true,
+      "dependencies": {
+        "@rushstack/node-core-library": "5.10.2",
+        "@rushstack/terminal": "0.14.5",
+        "@rushstack/typings-generator": "0.14.17",
+        "pseudolocale": "~1.1.0",
+        "xmldoc": "~1.1.2"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/lookup-by-path": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/lookup-by-path/-/lookup-by-path-0.5.2.tgz",
+      "integrity": "sha512-r0i+pVMergDWxrrNwKAFzigsx2mICxymHLslJJ6W3ozcsLeTMdZ/74mNhdSXYKUqw0Y/abXt1p+R6b7/jLF4Yw==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/module-minifier": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/module-minifier/-/module-minifier-0.7.0.tgz",
+      "integrity": "sha512-dS7acIB7y/rX/Zy/tAZuc0ZymRMQcSpniW77pz0jPvuKAKw+kEDivsISmRgZjbhIRK25FgSuGEaf0Ym/eFWySQ==",
+      "dev": true,
+      "dependencies": {
+        "@rushstack/worker-pool": "0.5.0",
+        "serialize-javascript": "6.0.0",
+        "source-map": "~0.7.3",
+        "terser": "^5.9.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/module-minifier/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/node-core-library": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.9.0.tgz",
-      "integrity": "sha512-MMsshEWkTbXqxqFxD4gcIUWQOCeBChlGczdZbHfqmNZQFLHB3yWxDFSMHFUdu2/OB9NUk7Awn5qRL+rws4HQNg==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.10.2.tgz",
+      "integrity": "sha512-xOF/2gVJZTfjTxbo4BDj9RtQq/HFnrrKdtem4JkyRLnwsRz2UDTg8gA1/et10fBx5RxmZD9bYVGST69W8ME5OQ==",
       "dev": true,
       "dependencies": {
         "ajv": "~8.13.0",
@@ -4415,6 +5457,326 @@
         "resolve": "~1.22.1",
         "semver": "~7.5.4"
       },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/node-core-library/node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/package-deps-hash": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/package-deps-hash/-/package-deps-hash-4.3.3.tgz",
+      "integrity": "sha512-ePzorEkUoaKHn7X149ZVUtV6qLYh7dIX4KWbD90GrqK/Shx3mpy0+g2XfXKudq6QuQjNdiraF99BE6D0DKnTcA==",
+      "dev": true,
+      "dependencies": {
+        "@rushstack/node-core-library": "5.10.2"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/package-extractor": {
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@rushstack/package-extractor/-/package-extractor-0.10.7.tgz",
+      "integrity": "sha512-w76rvpslrMKV/eOuEvWbol0vCQ81qwdOnjPgO3+SY2UqlKdqKWnwSWYy6kAGzd0QM7LyNrAgTmFJdYyz4elxFA==",
+      "dev": true,
+      "dependencies": {
+        "@pnpm/link-bins": "~5.3.7",
+        "@rushstack/node-core-library": "5.10.2",
+        "@rushstack/terminal": "0.14.5",
+        "@rushstack/ts-command-line": "4.23.3",
+        "ignore": "~5.1.6",
+        "jszip": "~3.8.0",
+        "minimatch": "~3.0.3",
+        "npm-packlist": "~2.1.2",
+        "semver": "~7.5.4"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/rig-package": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.5.3.tgz",
+      "integrity": "sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "~1.22.1",
+        "strip-json-comments": "~3.1.1"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/rig-package/node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/rush-amazon-s3-build-cache-plugin": {
+      "version": "5.148.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/rush-amazon-s3-build-cache-plugin/-/rush-amazon-s3-build-cache-plugin-5.148.0.tgz",
+      "integrity": "sha512-W+07Q5efsIG4RDEbuh+9VPBfrLpW7PnOZFllEkVwtQdvy4dFmM0iP0jZ+kARbejMFK2EBr6D78HzMJe6zMlL/w==",
+      "dev": true,
+      "dependencies": {
+        "@rushstack/node-core-library": "5.10.2",
+        "@rushstack/rush-sdk": "5.148.0",
+        "@rushstack/terminal": "0.14.5",
+        "https-proxy-agent": "~5.0.0"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/rush-azure-storage-build-cache-plugin": {
+      "version": "5.148.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/rush-azure-storage-build-cache-plugin/-/rush-azure-storage-build-cache-plugin-5.148.0.tgz",
+      "integrity": "sha512-5//eH4NwKYHd5wdZCDaA/gGUucD+OEz8mLfI4kSjmpz8iPACGXdqJY/1bKKxz/cwvfzZdvVZ+JuHHE+IhSPEPw==",
+      "dev": true,
+      "dependencies": {
+        "@azure/identity": "~4.5.0",
+        "@azure/storage-blob": "~12.26.0",
+        "@rushstack/node-core-library": "5.10.2",
+        "@rushstack/rush-sdk": "5.148.0",
+        "@rushstack/terminal": "0.14.5"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/rush-http-build-cache-plugin": {
+      "version": "5.148.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/rush-http-build-cache-plugin/-/rush-http-build-cache-plugin-5.148.0.tgz",
+      "integrity": "sha512-YMkofrrkm1zkt9ErEAIgJFuLWbIeb6kJRrMe71BAl/NXWdma2iicYVx9FRnrMTJp7sFzmYK7IOuUUEWBjvtMOA==",
+      "dev": true,
+      "dependencies": {
+        "@rushstack/node-core-library": "5.10.2",
+        "@rushstack/rush-sdk": "5.148.0",
+        "https-proxy-agent": "~5.0.0"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/rush-sdk": {
+      "version": "5.148.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/rush-sdk/-/rush-sdk-5.148.0.tgz",
+      "integrity": "sha512-0/W4nyLi/DVgaULe7EsGvxyibMsSL5GW39ZY/Rc2tycjgEJBEUYP0dsBdmUlK1OQRYurEkaT+j5HyC4VPnrBbw==",
+      "dev": true,
+      "dependencies": {
+        "@pnpm/lockfile.types": "~1.0.3",
+        "@rushstack/lookup-by-path": "0.5.2",
+        "@rushstack/node-core-library": "5.10.2",
+        "@rushstack/package-deps-hash": "4.3.3",
+        "@rushstack/terminal": "0.14.5",
+        "tapable": "2.2.1"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/rush-sdk/node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/set-webpack-public-path-plugin": {
+      "version": "5.1.64",
+      "resolved": "https://registry.npmjs.org/@rushstack/set-webpack-public-path-plugin/-/set-webpack-public-path-plugin-5.1.64.tgz",
+      "integrity": "sha512-HH07DOSaYg+8dg4k1VtZf1ef0hawNpgMvaUEMy2crDCn21JS+CcO6+Fjq1aAHBQrALt3jO0li0KJPfDCCCwULg==",
+      "dev": true,
+      "dependencies": {
+        "@rushstack/node-core-library": "5.10.2",
+        "@rushstack/webpack-plugin-utilities": "0.4.64"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "webpack": "^5.68.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/stream-collator": {
+      "version": "4.1.81",
+      "resolved": "https://registry.npmjs.org/@rushstack/stream-collator/-/stream-collator-4.1.81.tgz",
+      "integrity": "sha512-T+arXFpZveBuxTQ6DtfeD3hXSugaiB84hjJmVszKAtApF2YhJqNqI4prOtZshbtNkYlovj0tDLwO7h0KIXRiLA==",
+      "dev": true,
+      "dependencies": {
+        "@rushstack/node-core-library": "5.10.2",
+        "@rushstack/terminal": "0.14.5"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/terminal": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.14.5.tgz",
+      "integrity": "sha512-TEOpNwwmsZVrkp0omnuTUTGZRJKTr6n6m4OITiNjkqzLAkcazVpwR1SOtBg6uzpkIBLgrcNHETqI8rbw3uiUfw==",
+      "dev": true,
+      "dependencies": {
+        "@rushstack/node-core-library": "5.10.2",
+        "supports-color": "~8.1.1"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/ts-command-line": {
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.23.3.tgz",
+      "integrity": "sha512-HazKL8fv4HMQMzrKJCrOrhyBPPdzk7iajUXgsASwjQ8ROo1cmgyqxt/k9+SdmrNLGE1zATgRqMUH3s/6smbRMA==",
+      "dev": true,
+      "dependencies": {
+        "@rushstack/terminal": "0.14.5",
+        "@types/argparse": "1.0.38",
+        "argparse": "~1.0.9",
+        "string-argv": "~0.3.1"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/typings-generator": {
+      "version": "0.14.17",
+      "resolved": "https://registry.npmjs.org/@rushstack/typings-generator/-/typings-generator-0.14.17.tgz",
+      "integrity": "sha512-OpD5BkQoa5TyARPQw+H3ofEkJ8tV2k576pdXRZ1qvUmJiNs5s+1Ps25PLH2qH+ia8vCGDFgMTNU7PAc5VkY6jg==",
+      "dev": true,
+      "dependencies": {
+        "@rushstack/node-core-library": "5.10.2",
+        "@rushstack/terminal": "0.14.5",
+        "chokidar": "~3.4.0",
+        "fast-glob": "~3.3.1"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/typings-generator/node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/webpack-plugin-utilities": {
+      "version": "0.4.64",
+      "resolved": "https://registry.npmjs.org/@rushstack/webpack-plugin-utilities/-/webpack-plugin-utilities-0.4.64.tgz",
+      "integrity": "sha512-+S0Y1VyQ3AFA9LJhDiLHJXb45LSz0TbQ0fy1kaAVAHWl80TIzatve0brGmUbqa1kEF/v6nURHnNFIbTchC9E1Q==",
+      "dev": true,
+      "dependencies": {
+        "memfs": "4.12.0",
+        "webpack-merge": "~5.8.0"
+      },
+      "peerDependencies": {
+        "@types/webpack": "^4.39.8",
+        "webpack": "^5.35.1 || ^4.31.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/webpack": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/webpack5-localization-plugin": {
+      "version": "0.11.24",
+      "resolved": "https://registry.npmjs.org/@rushstack/webpack5-localization-plugin/-/webpack5-localization-plugin-0.11.24.tgz",
+      "integrity": "sha512-oW2EOq7RFoX7CYmSUC8eEBgPzSt+UyC8XvKBZAUrE+HgsurGTKYd+g9GQjMgjmJv9K6JK1aWhsngjF8N4rW/xw==",
+      "dev": true,
+      "dependencies": {
+        "@rushstack/localization-utilities": "0.12.17",
+        "@rushstack/node-core-library": "5.10.2",
+        "@rushstack/terminal": "0.14.5"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "webpack": "^5.68.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/webpack5-module-minifier-plugin": {
+      "version": "5.5.84",
+      "resolved": "https://registry.npmjs.org/@rushstack/webpack5-module-minifier-plugin/-/webpack5-module-minifier-plugin-5.5.84.tgz",
+      "integrity": "sha512-i8i0C6r34yeHW88IAF/vz/V3dwEngG5FbuVU2o+KUDK6AROGe207v362SampIkPO3XKJ6P5i8VPahxBTenoQpA==",
+      "dev": true,
+      "dependencies": {
+        "@rushstack/worker-pool": "0.5.0",
+        "@types/estree": "1.0.5",
+        "@types/tapable": "1.0.6",
+        "tapable": "2.2.1"
+      },
+      "engines": {
+        "node": ">=14.19.0"
+      },
+      "peerDependencies": {
+        "@rushstack/module-minifier": "*",
+        "@types/node": "*",
+        "webpack": "^5.68.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/webpack5-module-minifier-plugin/node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/@rushstack/worker-pool": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/worker-pool/-/worker-pool-0.5.0.tgz",
+      "integrity": "sha512-NM9ttY0aiAtb8ykNADoZlLEQSdrSQ7AtlJ/i4+SQWn+4v4nysu4VKVQW/IejbSZkBosBm3JTfPhzle+ASg2VXg==",
+      "dev": true,
       "peerDependencies": {
         "@types/node": "*"
       },
@@ -4454,11 +5816,143 @@
         }
       }
     },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/autoprefixer": {
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.1.tgz",
+      "integrity": "sha512-w3b5y1PXWlhYulevrTJ0lizkQ5CyqfeU6BIRDbuhsMupstHQOeb1Ur80tcB1zxSu7AwyY/qCQ7Vvqklh31ZBFw==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.7.2",
+        "caniuse-lite": "^1.0.30001006",
+        "chalk": "^2.4.2",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^7.0.21",
+        "postcss-value-parser": "^4.0.2"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/chalk/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@microsoft/sp-build-core-tasks/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/jsonpath-plus": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
+      "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
+      "dev": true,
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@microsoft/sp-build-core-tasks/node_modules/lru-cache": {
       "version": "6.0.0",
@@ -4472,25 +5966,85 @@
         "node": ">=10"
       }
     },
-    "node_modules/@microsoft/sp-build-core-tasks/node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/memfs": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.12.0.tgz",
+      "integrity": "sha512-74wDsex5tQDSClVkeK1vtxqYCAgCoXxx+K4NSHzgU/muYVYByFqa+0RnrPO9NM6naWm1+G9JmZ0p6QHhXmeYfA==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.16.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
+        "@jsonjoy.com/json-pack": "^1.0.3",
+        "@jsonjoy.com/util": "^1.3.0",
+        "tree-dump": "^1.0.1",
+        "tslib": "^2.0.0"
       },
       "engines": {
-        "node": ">= 0.4"
+        "node": ">= 4.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
       }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/schema-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/schema-utils/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/schema-utils/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/@microsoft/sp-build-core-tasks/node_modules/semver": {
       "version": "7.5.4",
@@ -4507,6 +6061,67 @@
         "node": ">=10"
       }
     },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/webpack": {
+      "version": "5.95.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.95.0.tgz",
+      "integrity": "sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.5",
+        "@webassemblyjs/ast": "^1.12.1",
+        "@webassemblyjs/wasm-edit": "^1.12.1",
+        "@webassemblyjs/wasm-parser": "^1.12.1",
+        "acorn": "^8.7.1",
+        "acorn-import-attributes": "^1.9.5",
+        "browserslist": "^4.21.10",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.17.1",
+        "es-module-lexer": "^1.2.1",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "json-parse-even-better-errors": "^2.3.1",
+        "loader-runner": "^4.2.0",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.2.0",
+        "tapable": "^2.1.1",
+        "terser-webpack-plugin": "^5.3.10",
+        "watchpack": "^2.4.1",
+        "webpack-sources": "^3.2.3"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@microsoft/sp-build-core-tasks/node_modules/webpack/node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@microsoft/sp-build-core-tasks/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -4514,9 +6129,9 @@
       "dev": true
     },
     "node_modules/@microsoft/sp-build-web": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-build-web/-/sp-build-web-1.20.2.tgz",
-      "integrity": "sha512-VDWfJqi42C4jqS7SvCLtokK3d3v7FhQEjFRwxIOWu0x10YhzgMmQS66412SnSQlFH1AQlG6QHzPJu2/noGHaPg==",
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-build-web/-/sp-build-web-1.21.0-beta.0.tgz",
+      "integrity": "sha512-7pkkgoCEvQR4ZTQYuBUKhMu1Md1GvVtorODJxMy0PH3OkEpNZRhrJcdKavTa9w+S+KaDn7zics8o/0zVAJrlOw==",
       "dev": true,
       "dependencies": {
         "@microsoft/gulp-core-build": "3.19.0",
@@ -4524,30 +6139,125 @@
         "@microsoft/gulp-core-build-serve": "3.13.0",
         "@microsoft/gulp-core-build-typescript": "8.6.3",
         "@microsoft/gulp-core-build-webpack": "6.0.3",
-        "@microsoft/sp-build-core-tasks": "1.20.2",
+        "@microsoft/sp-build-core-tasks": "1.21.0-beta.0",
         "gulp": "4.0.2",
         "semver": "~7.3.2",
-        "true-case-path": "~2.2.1",
-        "webpack": "~5.88.1",
+        "webpack": "~5.95.0",
         "yargs": "~4.6.0"
       },
       "engines": {
         "node": ">=18.17.1 <19.0.0"
       }
     },
-    "node_modules/@microsoft/sp-component-base": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-component-base/-/sp-component-base-1.20.0.tgz",
-      "integrity": "sha512-WqSO70PGm3+uWozOx5lzA0TPkN+P5ug8XCSO1v0mnPe58dr6XWq7SG4aq+K6P0OfpQwbtC2fN816j2qJww/TIA==",
+    "node_modules/@microsoft/sp-build-web/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
       "dependencies": {
-        "@fluentui/react": "^8.117.5",
-        "@microsoft/sp-core-library": "1.20.0",
-        "@microsoft/sp-diagnostics": "1.20.0",
-        "@microsoft/sp-dynamic-data": "1.20.0",
-        "@microsoft/sp-http": "1.20.0",
-        "@microsoft/sp-lodash-subset": "1.20.0",
-        "@microsoft/sp-module-interfaces": "1.20.2",
-        "@microsoft/sp-page-context": "1.20.0",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@microsoft/sp-build-web/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/@microsoft/sp-build-web/node_modules/schema-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@microsoft/sp-build-web/node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@microsoft/sp-build-web/node_modules/webpack": {
+      "version": "5.95.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.95.0.tgz",
+      "integrity": "sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.5",
+        "@webassemblyjs/ast": "^1.12.1",
+        "@webassemblyjs/wasm-edit": "^1.12.1",
+        "@webassemblyjs/wasm-parser": "^1.12.1",
+        "acorn": "^8.7.1",
+        "acorn-import-attributes": "^1.9.5",
+        "browserslist": "^4.21.10",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.17.1",
+        "es-module-lexer": "^1.2.1",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "json-parse-even-better-errors": "^2.3.1",
+        "loader-runner": "^4.2.0",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.2.0",
+        "tapable": "^2.1.1",
+        "terser-webpack-plugin": "^5.3.10",
+        "watchpack": "^2.4.1",
+        "webpack-sources": "^3.2.3"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@microsoft/sp-component-base": {
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-component-base/-/sp-component-base-1.21.0-beta.0.tgz",
+      "integrity": "sha512-RdldTtC4V/LyE2JMXrjGJx3g3GSLLdXhxxMAc4xmpRs0dbuMCxngvRq2FDpUFLKP19lxc43M2YswACgJn0XP9A==",
+      "dependencies": {
+        "@fluentui/react": "^8.121.11",
+        "@microsoft/sp-core-library": "1.21.0-beta.0",
+        "@microsoft/sp-diagnostics": "1.21.0-beta.0",
+        "@microsoft/sp-dynamic-data": "1.21.0-beta.0",
+        "@microsoft/sp-http": "1.21.0-beta.0",
+        "@microsoft/sp-lodash-subset": "1.21.0-beta.0",
+        "@microsoft/sp-module-interfaces": "1.21.0-beta.0",
+        "@microsoft/sp-page-context": "1.21.0-beta.0",
+        "@swc/helpers": "0.5.12",
         "tslib": "2.3.1"
       },
       "engines": {
@@ -4555,11 +6265,12 @@
       }
     },
     "node_modules/@microsoft/sp-core-library": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.20.0.tgz",
-      "integrity": "sha512-RMookiROCKRhadmDWK9i/pC+hgyBP+R4j28RLpRsYZ5BA8UsLzFhyWrJJcehkF9CK3z/EPltJoDFuAVdv/taCw==",
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.21.0-beta.0.tgz",
+      "integrity": "sha512-x3FPdYdgwSJfILKhVhfpk4N+CFgH3BWyfA9lDN4qjb5GFSY2ec2DMZDrGzCIwHfCB0hcBLc7cetvUvKQ+8i0Kw==",
       "dependencies": {
-        "@microsoft/sp-module-interfaces": "1.20.2",
+        "@microsoft/sp-module-interfaces": "1.21.0-beta.0",
+        "@swc/helpers": "0.5.12",
         "tslib": "2.3.1"
       },
       "engines": {
@@ -5449,26 +7160,27 @@
       "dev": true
     },
     "node_modules/@microsoft/sp-diagnostics": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-diagnostics/-/sp-diagnostics-1.20.0.tgz",
-      "integrity": "sha512-I0OVNuN2RMPxpl/seu67ab7XvNsUGaw0eaWnHpP52GazhyERux3OK+aAlTADyBeZuNUcvWpO3qfUbfpSD+MDPQ==",
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-diagnostics/-/sp-diagnostics-1.21.0-beta.0.tgz",
+      "integrity": "sha512-NROi8h3N0UH1sxpiz8b8Xt4mt4O2IRu7NHy/NNx0V4Z3d184rzlVkXY+cRBp3xn+8i8SjNK+4uylESYH0sXjnA==",
       "dependencies": {
-        "@microsoft/sp-core-library": "1.20.0",
-        "@microsoft/sp-lodash-subset": "1.20.0"
+        "@microsoft/sp-core-library": "1.21.0-beta.0",
+        "@microsoft/sp-lodash-subset": "1.21.0-beta.0"
       },
       "engines": {
         "node": ">=18.17.1 <19.0.0"
       }
     },
     "node_modules/@microsoft/sp-dynamic-data": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.20.0.tgz",
-      "integrity": "sha512-g3XiC0rmsRUywn5sZopicOf8tUlz/s8iNae23fyoJSFFkUV5DpxUbNqcdJTaTOeLpi/UT1D9EbrmSC8PGDun2Q==",
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.21.0-beta.0.tgz",
+      "integrity": "sha512-Xi/wdvNMnSkYm60oCEKel2x8W/nebMpUEpASfd99na5oj4L4kOSJFqpGQ9S4ZDo7pBDVFjuHkwT4/rimsjz8nQ==",
       "dependencies": {
-        "@microsoft/sp-core-library": "1.20.0",
-        "@microsoft/sp-diagnostics": "1.20.0",
-        "@microsoft/sp-lodash-subset": "1.20.0",
-        "@microsoft/sp-module-interfaces": "1.20.2",
+        "@microsoft/sp-core-library": "1.21.0-beta.0",
+        "@microsoft/sp-diagnostics": "1.21.0-beta.0",
+        "@microsoft/sp-lodash-subset": "1.21.0-beta.0",
+        "@microsoft/sp-module-interfaces": "1.21.0-beta.0",
+        "@swc/helpers": "0.5.12",
         "tslib": "2.3.1"
       },
       "engines": {
@@ -5476,14 +7188,15 @@
       }
     },
     "node_modules/@microsoft/sp-http": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.20.0.tgz",
-      "integrity": "sha512-6pYRkFMN2WxwT654uUJiyOMFHWQ8xHbUmBdwklpsK5b6zGVPnYb5cWI859E2jn+3XLrmc8pQbI+jOPKJSz/CVw==",
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.21.0-beta.0.tgz",
+      "integrity": "sha512-lHuyK8rKK0FBnzeIVS7VAByVgTYnyd/AGeYcmee5puskDASen9Lww6jsR0cdMdWGGQaodvwi347YjiLBbo2tgA==",
       "dependencies": {
-        "@microsoft/sp-core-library": "1.20.0",
-        "@microsoft/sp-diagnostics": "1.20.0",
-        "@microsoft/sp-http-base": "1.20.0",
-        "@microsoft/sp-http-msgraph": "1.20.0",
+        "@microsoft/sp-core-library": "1.21.0-beta.0",
+        "@microsoft/sp-diagnostics": "1.21.0-beta.0",
+        "@microsoft/sp-http-base": "1.21.0-beta.0",
+        "@microsoft/sp-http-msgraph": "1.21.0-beta.0",
+        "@swc/helpers": "0.5.12",
         "tslib": "2.3.1"
       },
       "engines": {
@@ -5491,30 +7204,30 @@
       }
     },
     "node_modules/@microsoft/sp-http-base": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-http-base/-/sp-http-base-1.20.0.tgz",
-      "integrity": "sha512-QSxG/+UKauLP+x2p8YzBAL0BN9+66PAd1fK0a7zKYF1VYLAnwpEUa2DJKW2BWzYx2O8a+9po2cnkeAu7WeBAuA==",
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-http-base/-/sp-http-base-1.21.0-beta.0.tgz",
+      "integrity": "sha512-89xyU6j3yIlmxgaxFbgBcPDfaYADI9ZZoy4z0ndz/f0ACc6Ix73OoFrrlecR9C4TPpvL6xvRJtKZrw5NL7Jm4Q==",
       "dependencies": {
-        "@microsoft/sp-core-library": "1.20.0",
-        "@microsoft/sp-diagnostics": "1.20.0",
-        "@microsoft/sp-page-context": "1.20.0",
+        "@microsoft/sp-core-library": "1.21.0-beta.0",
+        "@microsoft/sp-diagnostics": "1.21.0-beta.0",
+        "@microsoft/sp-page-context": "1.21.0-beta.0",
         "@microsoft/teams-js-v2": "npm:@microsoft/teams-js@2.24.0",
+        "@swc/helpers": "0.5.12",
         "adal-angular": "1.0.16",
-        "msalBrowserLegacy": "npm:@azure/msal-browser@2.22.0",
-        "msalLegacy": "npm:msal@1.4.12",
         "tslib": "2.3.1"
       }
     },
     "node_modules/@microsoft/sp-http-msgraph": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-http-msgraph/-/sp-http-msgraph-1.20.0.tgz",
-      "integrity": "sha512-NLJyFwe+y+OIpaYYt67I9riV7tUbGr1Y663NQvmP+ZC7US2cQiVhWGB/LgIPkyxKnkcAzYahYB940NiqULqZNQ==",
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-http-msgraph/-/sp-http-msgraph-1.21.0-beta.0.tgz",
+      "integrity": "sha512-usJrYTgpGjKSJKC7u6UjmNl/ow89g6tFVcxZ9saTX+w49OwdYY5AqK6/TKaPKNrscMJIQ5JAoPxMdj5ap+FjNQ==",
       "dependencies": {
         "@microsoft/microsoft-graph-clientv1": "npm:@microsoft/microsoft-graph-client@1.7.2-spfx",
-        "@microsoft/sp-core-library": "1.20.0",
-        "@microsoft/sp-diagnostics": "1.20.0",
-        "@microsoft/sp-http-base": "1.20.0",
-        "@microsoft/sp-loader": "1.20.0",
+        "@microsoft/sp-core-library": "1.21.0-beta.0",
+        "@microsoft/sp-diagnostics": "1.21.0-beta.0",
+        "@microsoft/sp-http-base": "1.21.0-beta.0",
+        "@microsoft/sp-loader": "1.21.0-beta.0",
+        "@swc/helpers": "0.5.12",
         "tslib": "2.3.1"
       },
       "peerDependencies": {
@@ -5522,16 +7235,17 @@
       }
     },
     "node_modules/@microsoft/sp-image-helper": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-image-helper/-/sp-image-helper-1.20.0.tgz",
-      "integrity": "sha512-rLlRE/DLNCYg5+0sCnQDtFntuLehCLrU3HxKHdvKskep1TJdMM+k7GEm056PW3dGZQWanX8ddlBxnJZLd5EkTQ==",
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-image-helper/-/sp-image-helper-1.21.0-beta.0.tgz",
+      "integrity": "sha512-9WQFtNWEBcGPELFRoSOIUqrX7PL0+Oa/X3Ef4uA2iqUFpFXOtDweTz7wUWtmXr15nWXTI5NuhVfNm3ygtuEGeQ==",
       "dependencies": {
-        "@microsoft/sp-core-library": "1.20.0",
-        "@microsoft/sp-diagnostics": "1.20.0",
-        "@microsoft/sp-http-base": "1.20.0",
-        "@microsoft/sp-loader": "1.20.0",
-        "@microsoft/sp-lodash-subset": "1.20.0",
-        "@microsoft/sp-page-context": "1.20.0",
+        "@microsoft/sp-core-library": "1.21.0-beta.0",
+        "@microsoft/sp-diagnostics": "1.21.0-beta.0",
+        "@microsoft/sp-http-base": "1.21.0-beta.0",
+        "@microsoft/sp-loader": "1.21.0-beta.0",
+        "@microsoft/sp-lodash-subset": "1.21.0-beta.0",
+        "@microsoft/sp-page-context": "1.21.0-beta.0",
+        "@swc/helpers": "0.5.12",
         "tslib": "2.3.1"
       },
       "engines": {
@@ -5545,20 +7259,21 @@
       }
     },
     "node_modules/@microsoft/sp-loader": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.20.0.tgz",
-      "integrity": "sha512-rTyI1oWWu1WB+QbRpqF4v2Q9F59pmdEQvpCxgqjvgdFVqdKQmev2kpPeTJpAv63nIJmJPX1a1jOPyc/2qlDAvA==",
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.21.0-beta.0.tgz",
+      "integrity": "sha512-OYO0LsOmu/Fsub7rfKKqgTR7s/gL3EICYUFhegSPE0FhRvE77qnZvv6E6BZQnHsHmutHcJWQ8OwsovH/56grlA==",
       "dependencies": {
-        "@fluentui/react": "^8.117.5",
-        "@microsoft/sp-core-library": "1.20.0",
-        "@microsoft/sp-diagnostics": "1.20.0",
-        "@microsoft/sp-dynamic-data": "1.20.0",
-        "@microsoft/sp-http-base": "1.20.0",
-        "@microsoft/sp-lodash-subset": "1.20.0",
-        "@microsoft/sp-module-interfaces": "1.20.2",
-        "@microsoft/sp-odata-types": "1.20.0",
-        "@microsoft/sp-page-context": "1.20.0",
-        "@rushstack/loader-raw-script": "1.4.64",
+        "@fluentui/react": "^8.121.11",
+        "@microsoft/sp-core-library": "1.21.0-beta.0",
+        "@microsoft/sp-diagnostics": "1.21.0-beta.0",
+        "@microsoft/sp-dynamic-data": "1.21.0-beta.0",
+        "@microsoft/sp-http-base": "1.21.0-beta.0",
+        "@microsoft/sp-lodash-subset": "1.21.0-beta.0",
+        "@microsoft/sp-module-interfaces": "1.21.0-beta.0",
+        "@microsoft/sp-odata-types": "1.21.0-beta.0",
+        "@microsoft/sp-page-context": "1.21.0-beta.0",
+        "@rushstack/loader-raw-script": "1.4.80",
+        "@swc/helpers": "0.5.12",
         "@types/requirejs": "2.1.29",
         "raw-loader": "~0.5.1",
         "react": "17.0.1",
@@ -5575,10 +7290,11 @@
       }
     },
     "node_modules/@microsoft/sp-lodash-subset": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.20.0.tgz",
-      "integrity": "sha512-xKOHUarrX3tVG/PAJ60KJPzuk7aoOUNuoRyB9/M79Mo4iidyT+7PD9XmS5tcdseUfPzi6N2uE7X9BYsbCG0EbA==",
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.21.0-beta.0.tgz",
+      "integrity": "sha512-3GLhsKdll36QRoEpimK5GecywdhSCLAdvBe6RDuqAKomzfDzze/PTNGj6+F+owhuPW8A57ZpCtCeThZQpw5Esw==",
       "dependencies": {
+        "@swc/helpers": "0.5.12",
         "@types/lodash": "4.14.117",
         "tslib": "2.3.1"
       },
@@ -5587,21 +7303,21 @@
       }
     },
     "node_modules/@microsoft/sp-module-interfaces": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.20.2.tgz",
-      "integrity": "sha512-s4hm7PNes++7uviF+aJsqLsrzcaQttye/xuW+8IxMg1b2v/ys1bvfKUucM2N9T2hsz0q8+yWAwwuAl1C3PgBtA==",
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.21.0-beta.0.tgz",
+      "integrity": "sha512-cqFl4bRSIR/OZIDzat6T9XfBjvYyTnd/qmuZGKBe8VqsMxBAlHb7cpQ1tt3y+0Yx5fGl6hnREF2aHjNvI1AKDg==",
       "dependencies": {
-        "@rushstack/node-core-library": "5.9.0",
-        "z-schema": "4.2.4"
+        "@rushstack/node-core-library": "5.10.2",
+        "z-schema": "6.0.2"
       },
       "engines": {
         "node": ">=18.17.1 <19.0.0"
       }
     },
     "node_modules/@microsoft/sp-module-interfaces/node_modules/@rushstack/node-core-library": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.9.0.tgz",
-      "integrity": "sha512-MMsshEWkTbXqxqFxD4gcIUWQOCeBChlGczdZbHfqmNZQFLHB3yWxDFSMHFUdu2/OB9NUk7Awn5qRL+rws4HQNg==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.10.2.tgz",
+      "integrity": "sha512-xOF/2gVJZTfjTxbo4BDj9RtQq/HFnrrKdtem4JkyRLnwsRz2UDTg8gA1/et10fBx5RxmZD9bYVGST69W8ME5OQ==",
       "dependencies": {
         "ajv": "~8.13.0",
         "ajv-draft-04": "~1.0.0",
@@ -5650,10 +7366,13 @@
       }
     },
     "node_modules/@microsoft/sp-module-interfaces/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "optional": true
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/@microsoft/sp-module-interfaces/node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -5718,29 +7437,30 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@microsoft/sp-module-interfaces/node_modules/z-schema": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.4.tgz",
-      "integrity": "sha512-YvBeW5RGNeNzKOUJs3rTL4+9rpcvHXt5I051FJbOcitV8bl40pEfcG0Q+dWSwS0/BIYrMZ/9HHoqLllMkFhD0w==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-6.0.2.tgz",
+      "integrity": "sha512-9fQb2ZhpMD0ZQXYw0ll5ya6uLQm3Xtt4DXY2RV3QO1QVI4ihSzSWirlgkDsMgGg4qK0EV4tLOJgRSH2bn0cbIw==",
       "dependencies": {
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
-        "validator": "^13.6.0"
+        "validator": "^13.7.0"
       },
       "bin": {
         "z-schema": "bin/z-schema"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "commander": "^2.7.1"
+        "commander": "^11.0.0"
       }
     },
     "node_modules/@microsoft/sp-odata-types": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-odata-types/-/sp-odata-types-1.20.0.tgz",
-      "integrity": "sha512-PbdK2U+1n44Msmkt5Y2PvYfuckDYURjLA0kAQSA9YxFYGe00N4EVj8CN0HegK59F/KGfAZdqM1OlQCJ+4SClGg==",
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-odata-types/-/sp-odata-types-1.21.0-beta.0.tgz",
+      "integrity": "sha512-Hds8gy0QKhlYr2d7viB8b3cVNvIWvBalopcmTR3Ai+x1PXTRHHbtV2GhMiJVyouzf7uV4hf1GteVg1XdvJx0VA==",
       "dependencies": {
+        "@swc/helpers": "0.5.12",
         "tslib": "2.3.1"
       },
       "engines": {
@@ -5748,10 +7468,11 @@
       }
     },
     "node_modules/@microsoft/sp-office-ui-fabric-core": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-office-ui-fabric-core/-/sp-office-ui-fabric-core-1.20.0.tgz",
-      "integrity": "sha512-4bVXNuO05WvMG1xnFEUcbT1wyg2e751QfI7ULRaIvG3597UEv3rKrdETut5QWyHrqmE3x+ERkcC0sHS/Y4Gh3w==",
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-office-ui-fabric-core/-/sp-office-ui-fabric-core-1.21.0-beta.0.tgz",
+      "integrity": "sha512-41Da7iFUSyEes3QQMDdAkBZUeNqfTVz5W5DhwPOZBNzh/dE5BbHQffja9lQgUzzhn5qo8pG8DQXUfrDRiUox8w==",
       "dependencies": {
+        "@swc/helpers": "0.5.12",
         "office-ui-fabric-core": "11.0.1",
         "tslib": "2.3.1"
       },
@@ -5760,15 +7481,16 @@
       }
     },
     "node_modules/@microsoft/sp-page-context": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.20.0.tgz",
-      "integrity": "sha512-4H8+QuPJTvyAlf/xbJ8OK/xoxGmaUATCvFIRcEtMfhgEjwcUICpkl7hHeOlPfmscrHafmW4nxTqj16IVIW66kQ==",
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.21.0-beta.0.tgz",
+      "integrity": "sha512-oiSKHdbOaWOHXHboNzsIvnasTxk7DpHg4yZi8yJlnAX6HlhVhFWyg9zfcOSTcAg5Ebenmf9Mn0rk8xU3Lu3qRQ==",
       "dependencies": {
-        "@microsoft/sp-core-library": "1.20.0",
-        "@microsoft/sp-diagnostics": "1.20.0",
-        "@microsoft/sp-dynamic-data": "1.20.0",
-        "@microsoft/sp-lodash-subset": "1.20.0",
-        "@microsoft/sp-odata-types": "1.20.0",
+        "@microsoft/sp-core-library": "1.21.0-beta.0",
+        "@microsoft/sp-diagnostics": "1.21.0-beta.0",
+        "@microsoft/sp-dynamic-data": "1.21.0-beta.0",
+        "@microsoft/sp-lodash-subset": "1.21.0-beta.0",
+        "@microsoft/sp-odata-types": "1.21.0-beta.0",
+        "@swc/helpers": "0.5.12",
         "tslib": "2.3.1"
       },
       "engines": {
@@ -5776,21 +7498,22 @@
       }
     },
     "node_modules/@microsoft/sp-property-pane": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-property-pane/-/sp-property-pane-1.20.0.tgz",
-      "integrity": "sha512-6cffQiTSM6fMdhAFvkZGvwWhUM0D/h3H5TDaXZGCuinHD5juJcvIjTRJDLfLp99ZM90yrwxhWG6qdt3Vb5FTnQ==",
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-property-pane/-/sp-property-pane-1.21.0-beta.0.tgz",
+      "integrity": "sha512-J1bbMdG8unzbDfTfL5+oaKD5QVtsHRZuOAO1+dF3//o8gO7w7igudtBW0LFtHC2zeZdCgd+gR499TabJ/E1QJg==",
       "dependencies": {
-        "@fluentui/react": "^8.117.5",
-        "@fluentui/react-components": "^9.54.4",
-        "@fluentui/react-icons": "~2.0.203",
-        "@fluentui/react-tabster": "^9.22.1",
-        "@microsoft/sp-component-base": "1.20.0",
-        "@microsoft/sp-core-library": "1.20.0",
-        "@microsoft/sp-diagnostics": "1.20.0",
-        "@microsoft/sp-dynamic-data": "1.20.0",
-        "@microsoft/sp-image-helper": "1.20.0",
-        "@microsoft/sp-lodash-subset": "1.20.0",
-        "@microsoft/sp-page-context": "1.20.0",
+        "@fluentui/react": "^8.121.11",
+        "@fluentui/react-components": "^9.56.8",
+        "@fluentui/react-icons": "~2.0.258",
+        "@fluentui/react-tabster": "^9.23.2",
+        "@microsoft/sp-component-base": "1.21.0-beta.0",
+        "@microsoft/sp-core-library": "1.21.0-beta.0",
+        "@microsoft/sp-diagnostics": "1.21.0-beta.0",
+        "@microsoft/sp-dynamic-data": "1.21.0-beta.0",
+        "@microsoft/sp-image-helper": "1.21.0-beta.0",
+        "@microsoft/sp-lodash-subset": "1.21.0-beta.0",
+        "@microsoft/sp-page-context": "1.21.0-beta.0",
+        "@swc/helpers": "0.5.12",
         "react": "17.0.1",
         "react-dom": "17.0.1",
         "tslib": "2.3.1"
@@ -5804,28 +7527,29 @@
       }
     },
     "node_modules/@microsoft/sp-top-actions": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-top-actions/-/sp-top-actions-1.20.0.tgz",
-      "integrity": "sha512-Ir07zIdwRJ3yHeHomu1ALsBb7Ohhdaud4UdKGpz3ghVk82xvHzNkWWIR7V8AVe6S991lEEnD9O9E1ASHsbTvJQ=="
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-top-actions/-/sp-top-actions-1.21.0-beta.0.tgz",
+      "integrity": "sha512-jcFwD81RGUX48TwQTSNqo7+1GmN+oWEWa1OXIQGnr/6Jar3f91m23T58roRtIVKlpVK3d12bdBtswmZAarOMRQ=="
     },
     "node_modules/@microsoft/sp-webpart-base": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/sp-webpart-base/-/sp-webpart-base-1.20.0.tgz",
-      "integrity": "sha512-kwW4MSBvbjxljZXwOhETZjrcGZryUhFtbBIbJ6hG6gbWsUNeZA4JBm5+jXsq07pOfYS8tIMfcYKpEEsbCEiHRw==",
+      "version": "1.21.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-webpart-base/-/sp-webpart-base-1.21.0-beta.0.tgz",
+      "integrity": "sha512-vytf0rfjcRi8DM7x2SF+RMr3VKVGTGPWXHgDprm3U3ERNEIqCMmv9Qxx1tltsXwuyqQFxZabrEEut30Kr5BzBQ==",
       "dependencies": {
-        "@fluentui/react": "^8.117.5",
-        "@microsoft/sp-component-base": "1.20.0",
-        "@microsoft/sp-core-library": "1.20.0",
-        "@microsoft/sp-diagnostics": "1.20.0",
-        "@microsoft/sp-http": "1.20.0",
-        "@microsoft/sp-http-base": "1.20.0",
-        "@microsoft/sp-loader": "1.20.0",
-        "@microsoft/sp-lodash-subset": "1.20.0",
-        "@microsoft/sp-module-interfaces": "1.20.2",
-        "@microsoft/sp-page-context": "1.20.0",
-        "@microsoft/sp-property-pane": "1.20.0",
-        "@microsoft/sp-top-actions": "1.20.0",
+        "@fluentui/react": "^8.121.11",
+        "@microsoft/sp-component-base": "1.21.0-beta.0",
+        "@microsoft/sp-core-library": "1.21.0-beta.0",
+        "@microsoft/sp-diagnostics": "1.21.0-beta.0",
+        "@microsoft/sp-http": "1.21.0-beta.0",
+        "@microsoft/sp-http-base": "1.21.0-beta.0",
+        "@microsoft/sp-loader": "1.21.0-beta.0",
+        "@microsoft/sp-lodash-subset": "1.21.0-beta.0",
+        "@microsoft/sp-module-interfaces": "1.21.0-beta.0",
+        "@microsoft/sp-page-context": "1.21.0-beta.0",
+        "@microsoft/sp-property-pane": "1.21.0-beta.0",
+        "@microsoft/sp-top-actions": "1.21.0-beta.0",
         "@microsoft/teams-js-v2": "npm:@microsoft/teams-js@2.24.0",
+        "@swc/helpers": "0.5.12",
         "@types/office-js": "1.0.36",
         "react": "17.0.1",
         "react-dom": "17.0.1",
@@ -5874,6 +7598,19 @@
         "uuid": "^9.0.0",
         "webpack": "~5.88.1",
         "xml": "~1.0.1"
+      }
+    },
+    "node_modules/@microsoft/spfx-heft-plugins/node_modules/@microsoft/sp-module-interfaces": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.20.2.tgz",
+      "integrity": "sha512-s4hm7PNes++7uviF+aJsqLsrzcaQttye/xuW+8IxMg1b2v/ys1bvfKUucM2N9T2hsz0q8+yWAwwuAl1C3PgBtA==",
+      "dev": true,
+      "dependencies": {
+        "@rushstack/node-core-library": "5.9.0",
+        "z-schema": "4.2.4"
+      },
+      "engines": {
+        "node": ">=18.17.1 <19.0.0"
       }
     },
     "node_modules/@microsoft/spfx-heft-plugins/node_modules/@rushstack/node-core-library": {
@@ -5980,80 +7717,12 @@
         }
       }
     },
-    "node_modules/@microsoft/spfx-heft-plugins/node_modules/body-parser": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+    "node_modules/@microsoft/spfx-heft-plugins/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.10.3",
-        "raw-body": "2.5.1",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/@microsoft/spfx-heft-plugins/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/@microsoft/spfx-heft-plugins/node_modules/express": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
-      "dev": true,
-      "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.20.0",
-        "content-disposition": "0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "0.5.0",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.7",
-        "qs": "6.10.3",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
+      "optional": true
     },
     "node_modules/@microsoft/spfx-heft-plugins/node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -6073,42 +7742,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@microsoft/spfx-heft-plugins/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
-    },
-    "node_modules/@microsoft/spfx-heft-plugins/node_modules/qs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
-      "dev": true,
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@microsoft/spfx-heft-plugins/node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-      "dev": true,
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/@microsoft/spfx-heft-plugins/node_modules/semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -6124,11 +7757,40 @@
         "node": ">=10"
       }
     },
+    "node_modules/@microsoft/spfx-heft-plugins/node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/@microsoft/spfx-heft-plugins/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/@microsoft/spfx-heft-plugins/node_modules/z-schema": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.4.tgz",
+      "integrity": "sha512-YvBeW5RGNeNzKOUJs3rTL4+9rpcvHXt5I051FJbOcitV8bl40pEfcG0Q+dWSwS0/BIYrMZ/9HHoqLllMkFhD0w==",
+      "dev": true,
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.6.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^2.7.1"
+      }
     },
     "node_modules/@microsoft/teams-js-v2": {
       "name": "@microsoft/teams-js",
@@ -6467,6 +8129,18 @@
         "url": "https://opencollective.com/pnpm"
       }
     },
+    "node_modules/@pnpm/crypto.polyfill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/crypto.polyfill/-/crypto.polyfill-1.0.0.tgz",
+      "integrity": "sha512-WbmsqqcUXKKaAF77ox1TQbpZiaQcr26myuMUu+WjUtoWYgD3VP6iKYEvSx35SZ6G2L316lu+pv+40A2GbWJc1w==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
     "node_modules/@pnpm/dependency-path": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/@pnpm/dependency-path/-/dependency-path-2.1.8.tgz",
@@ -6483,6 +8157,37 @@
       },
       "funding": {
         "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/dependency-path-lockfile-pre-v9": {
+      "name": "@pnpm/dependency-path",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@pnpm/dependency-path/-/dependency-path-2.1.8.tgz",
+      "integrity": "sha512-ywBaTjy0iSEF7lH3DlF8UXrdL2bw4AQFV2tTOeNeY7wc1W5CE+RHSJhf9MXBYcZPesqGRrPiU7Pimj3l05L9VA==",
+      "dev": true,
+      "dependencies": {
+        "@pnpm/crypto.base32-hash": "2.0.0",
+        "@pnpm/types": "9.4.2",
+        "encode-registry": "^3.0.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/dependency-path-lockfile-pre-v9/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@pnpm/dependency-path/node_modules/semver": {
@@ -6548,6 +8253,34 @@
         "url": "https://opencollective.com/pnpm"
       }
     },
+    "node_modules/@pnpm/lockfile.types": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@pnpm/lockfile.types/-/lockfile.types-1.0.3.tgz",
+      "integrity": "sha512-A7vUWktnhDkrIs+WmXm7AdffJVyVYJpQUEouya/DYhB+Y+tQ3BXjZ6CV0KybqLgI/8AZErgCJqFxA0GJH6QDjA==",
+      "dev": true,
+      "dependencies": {
+        "@pnpm/patching.types": "1.0.0",
+        "@pnpm/types": "12.2.0"
+      },
+      "engines": {
+        "node": ">=18.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/lockfile.types/node_modules/@pnpm/types": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/types/-/types-12.2.0.tgz",
+      "integrity": "sha512-5RtwWhX39j89/Tmyv2QSlpiNjErA357T/8r1Dkg+2lD3P7RuS7Xi2tChvmOC3VlezEFNcWnEGCOeKoGRkDuqFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
     "node_modules/@pnpm/package-bins": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@pnpm/package-bins/-/package-bins-4.1.0.tgz",
@@ -6572,6 +8305,18 @@
       "dev": true,
       "engines": {
         "node": ">=10.16"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@pnpm/patching.types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/patching.types/-/patching.types-1.0.0.tgz",
+      "integrity": "sha512-juCdQCC1USqLcOhVPl1tYReoTO9YH4fTullMnFXXcmpsDM7Dkn3tzuOQKC3oPoJ2ozv+0EeWWMtMGqn2+IM3pQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.12"
       },
       "funding": {
         "url": "https://opencollective.com/pnpm"
@@ -6718,67 +8463,6 @@
         "@rushstack/node-core-library": "3.53.2",
         "node-forge": "~1.3.1",
         "sudo": "~1.0.3"
-      }
-    },
-    "node_modules/@rushstack/debug-certificate-manager/node_modules/@rushstack/node-core-library": {
-      "version": "3.53.2",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.53.2.tgz",
-      "integrity": "sha512-FggLe5DQs0X9MNFeJN3/EXwb+8hyZUTEp2i+V1e8r4Va4JgkjBNY0BuEaQI+3DW6S4apV3UtXU3im17MSY00DA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "12.20.24",
-        "colors": "~1.2.1",
-        "fs-extra": "~7.0.1",
-        "import-lazy": "~4.0.0",
-        "jju": "~1.4.0",
-        "resolve": "~1.17.0",
-        "semver": "~7.3.0",
-        "z-schema": "~5.0.2"
-      }
-    },
-    "node_modules/@rushstack/debug-certificate-manager/node_modules/@types/node": {
-      "version": "12.20.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
-      "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
-      "dev": true
-    },
-    "node_modules/@rushstack/debug-certificate-manager/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
-    "node_modules/@rushstack/debug-certificate-manager/node_modules/validator": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
-      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/@rushstack/debug-certificate-manager/node_modules/z-schema": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
-      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
-      "dev": true,
-      "dependencies": {
-        "lodash.get": "^4.4.2",
-        "lodash.isequal": "^4.5.0",
-        "validator": "^13.7.0"
-      },
-      "bin": {
-        "z-schema": "bin/z-schema"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "commander": "^9.4.1"
       }
     },
     "node_modules/@rushstack/eslint-config": {
@@ -7366,9 +9050,9 @@
       "dev": true
     },
     "node_modules/@rushstack/loader-raw-script": {
-      "version": "1.4.64",
-      "resolved": "https://registry.npmjs.org/@rushstack/loader-raw-script/-/loader-raw-script-1.4.64.tgz",
-      "integrity": "sha512-OIuPkbIJhCw7CixrsB+9DcQDZEiZU3y3tW8kupKmFzbD6ny57ZvEAincBwnyxZdTBElgjz9jYUHFEBIWxse1Ug==",
+      "version": "1.4.80",
+      "resolved": "https://registry.npmjs.org/@rushstack/loader-raw-script/-/loader-raw-script-1.4.80.tgz",
+      "integrity": "sha512-vqepa33/SneMrvf3fP9cmHvumvZwCbuTEo+Zb75CfnAgl47pPQnE+Rwl3bHeUIa+HFs9ZhsBWcdtMH/YspNT1w==",
       "dependencies": {
         "loader-utils": "1.4.2"
       }
@@ -7567,9 +9251,9 @@
       }
     },
     "node_modules/@rushstack/node-core-library": {
-      "version": "3.53.3",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.53.3.tgz",
-      "integrity": "sha512-H0+T5koi5MFhJUd5ND3dI3bwLhvlABetARl78L3lWftJVQEPyzcgTStvTTRiIM5mCltyTM8VYm6BuCtNUuxD0Q==",
+      "version": "3.53.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.53.2.tgz",
+      "integrity": "sha512-FggLe5DQs0X9MNFeJN3/EXwb+8hyZUTEp2i+V1e8r4Va4JgkjBNY0BuEaQI+3DW6S4apV3UtXU3im17MSY00DA==",
       "dev": true,
       "dependencies": {
         "@types/node": "12.20.24",
@@ -7973,26 +9657,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@rushstack/rush-amazon-s3-build-cache-plugin/node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rushstack/rush-amazon-s3-build-cache-plugin/node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -8026,28 +9690,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@rushstack/rush-amazon-s3-build-cache-plugin/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
-    },
-    "node_modules/@rushstack/rush-amazon-s3-build-cache-plugin/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
-    },
-    "node_modules/@rushstack/rush-amazon-s3-build-cache-plugin/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/@rushstack/rush-amazon-s3-build-cache-plugin/node_modules/yallist": {
@@ -8266,26 +9908,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@rushstack/rush-http-build-cache-plugin/node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rushstack/rush-http-build-cache-plugin/node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -8319,28 +9941,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@rushstack/rush-http-build-cache-plugin/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
-    },
-    "node_modules/@rushstack/rush-http-build-cache-plugin/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
-    },
-    "node_modules/@rushstack/rush-http-build-cache-plugin/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/@rushstack/rush-http-build-cache-plugin/node_modules/yallist": {
@@ -8386,16 +9986,6 @@
         }
       }
     },
-    "node_modules/@rushstack/rush-sdk/node_modules/@types/node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
-      }
-    },
     "node_modules/@rushstack/rush-sdk/node_modules/ajv": {
       "version": "8.13.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
@@ -8424,21 +10014,6 @@
         "ajv": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@rushstack/rush-sdk/node_modules/form-data": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.3.tgz",
-      "integrity": "sha512-q5YBMeWy6E2Un0nMGWMgI65MAKtaylxfNJGJxpGh45YDciZB4epbWpaAfImil6CPAPTYB4sh0URQNDRIZG5F2w==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@rushstack/rush-sdk/node_modules/json-schema-traverse": {
@@ -9311,11 +10886,11 @@
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.12.tgz",
+      "integrity": "sha512-KMZNXiGibsW9kvZAO1Pam2JPTDBm+KSHMMHWdsyI/1DbIZjT2A6Gy3hblVXUMEDvUAKq+e0vL0X0o54owWji7g==",
       "dependencies": {
-        "tslib": "^2.8.0"
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@swc/helpers/node_modules/tslib": {
@@ -9465,9 +11040,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "version": "8.56.12",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
+      "integrity": "sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==",
       "dev": true,
       "dependencies": {
         "@types/estree": "*",
@@ -9503,18 +11078,6 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
-      "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
-    "node_modules/@types/express/node_modules/@types/express-serve-static-core": {
       "version": "4.19.6",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
       "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
@@ -9678,25 +11241,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@types/gulp/node_modules/fsevents": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-      "deprecated": "Upgrade to fsevents v2 to mitigate potential security issues",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.12.1"
-      },
-      "engines": {
-        "node": ">= 4.0"
       }
     },
     "node_modules/@types/gulp/node_modules/glob-parent": {
@@ -9962,13 +11506,28 @@
       "devOptional": true
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "form-data": "^4.0.0"
+        "form-data": "^3.0.0"
+      }
+    },
+    "node_modules/@types/node-fetch/node_modules/form-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.3.tgz",
+      "integrity": "sha512-q5YBMeWy6E2Un0nMGWMgI65MAKtaylxfNJGJxpGh45YDciZB4epbWpaAfImil6CPAPTYB4sh0URQNDRIZG5F2w==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@types/node-forge": {
@@ -11077,6 +12636,15 @@
         "acorn": "^8"
       }
     },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -12089,16 +13657,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -12137,21 +13695,21 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
+      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
       "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.5",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.2",
+        "qs": "6.10.3",
+        "raw-body": "2.5.1",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -12175,30 +13733,20 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
-    "node_modules/body/node_modules/bytes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
-      "integrity": "sha512-/x68VkHLeTl3/Ll8IvxdwzhrT+IyKc52e/oyHhA2RwqPqswSnjVbSddfPRwAsJtbilMAPSRWwAlpxdYsSWOTKQ==",
-      "dev": true
-    },
-    "node_modules/body/node_modules/raw-body": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
-      "integrity": "sha512-WmJJU2e9Y6M5UzTOkHaM7xJGAPQD8PNzx3bAd2+uhZAim6wDk6dAZxPVYLF67XhbR4hmKGh33Lpmh4XWrCH5Mg==",
+    "node_modules/body-parser/node_modules/raw-body": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
       "dev": true,
       "dependencies": {
-        "bytes": "1",
-        "string_decoder": "0.10"
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 0.8"
       }
-    },
-    "node_modules/body/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "dev": true
     },
     "node_modules/bonjour-service": {
       "version": "1.3.0",
@@ -13726,10 +15274,23 @@
       }
     },
     "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "dev": true
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
@@ -13748,9 +15309,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -15158,15 +16719,6 @@
         "once": "~1.3.0"
       }
     },
-    "node_modules/end-of-stream/node_modules/once": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-      "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
-      "dev": true,
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
     "node_modules/enhanced-resolve": {
       "version": "5.18.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
@@ -15922,16 +17474,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/eslint-webpack-plugin/node_modules/@types/eslint": {
-      "version": "8.56.12",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
-      "integrity": "sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
     "node_modules/eslint-webpack-plugin/node_modules/@types/istanbul-reports": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
@@ -16509,14 +18051,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.3.tgz",
-      "integrity": "sha512-6VyCijWQ+9O7WuVMTRBTl+cjNNIzD5cY5mQ1WM8r/LEkI2u8EYpOotESNwzNlyCn3g+dmjKYI6BmNneSr/FSRw==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
+      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
+        "body-parser": "1.20.0",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.5.0",
@@ -16535,7 +18077,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "6.10.3",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "0.18.0",
@@ -16761,6 +18303,24 @@
         }
       ]
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.1.1"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -16890,13 +18450,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -17466,20 +19019,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -17658,20 +19197,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -18161,25 +19686,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/glob-watcher/node_modules/fsevents": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-      "deprecated": "Upgrade to fsevents v2 to mitigate potential security issues",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.12.1"
-      },
-      "engines": {
-        "node": ">= 4.0"
       }
     },
     "node_modules/glob-watcher/node_modules/glob-parent": {
@@ -21764,6 +23270,15 @@
       "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
       "dev": true
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -23108,45 +24623,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
-    "node_modules/msalBrowserLegacy": {
-      "name": "@azure/msal-browser",
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.22.0.tgz",
-      "integrity": "sha512-ZpnbnzjYGRGHjWDPOLjSp47CQvhK927+W9avtLoNNCMudqs2dBfwj76lnJwObDE7TAKmCUueTiieglBiPb1mgQ==",
-      "deprecated": "A newer major version of this library is available. Please upgrade to the latest available version.",
-      "dependencies": {
-        "@azure/msal-common": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/msalBrowserLegacy/node_modules/@azure/msal-common": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.4.0.tgz",
-      "integrity": "sha512-WZdgq9f9O8cbxGzdRwLLMM5xjmLJ2mdtuzgXeiGxIRkVVlJ9nZ6sWnDFKa2TX8j72UXD1IfL0p/RYNoTXYoGfg==",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/msalLegacy": {
-      "name": "msal",
-      "version": "1.4.12",
-      "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.12.tgz",
-      "integrity": "sha512-gjupwQ6nvNL6mZkl5NIXyUmZhTiEMRu5giNdgHMh8l5EPOnV2Xj6nukY1NIxFacSTkEYUSDB47Pej9GxDYf+1w==",
-      "deprecated": "This package is no longer supported. Please use @azure/msal-browser instead.",
-      "dependencies": {
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/msalLegacy/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
@@ -23222,13 +24698,6 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
-    },
-    "node_modules/nan": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.1.tgz",
-      "integrity": "sha512-pfRR4ZcNTSm2ZFHaztuvbICf+hyiG6ecA06SfAxoPmuHjvMu0KUIae7Y8GyVkbBqeEIidsmXeYooWIX9+qjfRQ==",
-      "dev": true,
-      "optional": true
     },
     "node_modules/nanocolors": {
       "version": "0.2.13",
@@ -23392,9 +24861,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -24153,9 +25622,9 @@
       }
     },
     "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+      "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
       "dev": true,
       "dependencies": {
         "wrappy": "1"
@@ -24288,15 +25757,6 @@
       "dev": true,
       "dependencies": {
         "once": "~1.3.0"
-      }
-    },
-    "node_modules/orchestrator/node_modules/once": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-      "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
-      "dev": true,
-      "dependencies": {
-        "wrappy": "1"
       }
     },
     "node_modules/ordered-read-streams": {
@@ -25097,9 +26557,9 @@
       }
     },
     "node_modules/postcss-loader/node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "optional": true,
       "peer": true,
@@ -25448,9 +26908,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
       "dev": true,
       "dependencies": {
         "side-channel": "^1.0.4"
@@ -25516,19 +26976,29 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
+      "integrity": "sha512-WmJJU2e9Y6M5UzTOkHaM7xJGAPQD8PNzx3bAd2+uhZAim6wDk6dAZxPVYLF67XhbR4hmKGh33Lpmh4XWrCH5Mg==",
       "dev": true,
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "1",
+        "string_decoder": "0.10"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.8.0"
       }
+    },
+    "node_modules/raw-body/node_modules/bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+      "integrity": "sha512-/x68VkHLeTl3/Ll8IvxdwzhrT+IyKc52e/oyHhA2RwqPqswSnjVbSddfPRwAsJtbilMAPSRWwAlpxdYsSWOTKQ==",
+      "dev": true
+    },
+    "node_modules/raw-body/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "dev": true
     },
     "node_modules/raw-loader": {
       "version": "0.5.1",
@@ -25612,15 +27082,6 @@
       },
       "peerDependencies": {
         "react": "17.0.1"
-      }
-    },
-    "node_modules/react-dom/node_modules/scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
       }
     },
     "node_modules/react-is": {
@@ -27226,12 +28687,12 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "peer": true,
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
       "dependencies": {
-        "loose-envify": "^1.1.0"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     },
     "node_modules/schema-utils": {
@@ -28183,9 +29644,9 @@
       }
     },
     "node_modules/spfx-fast-serve-helpers/node_modules/@microsoft/load-themed-styles": {
-      "version": "2.0.161",
-      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-2.0.161.tgz",
-      "integrity": "sha512-Ijgi+tbjKNZRAzvEI7WVPikdNi8MWTHDpRq/adGxDhLXlawmyCoGvI2KBSmag1fThWcuT3jfvw4EOwgWnnzMJg==",
+      "version": "2.0.164",
+      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-2.0.164.tgz",
+      "integrity": "sha512-hi21fpZm+dwTf9q/7OqpN2kYoOPKqASK+ea50HsFhL4VMfNVnlUOTg5rFzSxFRQZUGrJ9Bdf/05r+2RYS7wygw==",
       "dev": true,
       "peer": true
     },
@@ -28255,20 +29716,6 @@
       "dev": true,
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/spfx-fast-serve-helpers/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/spfx-fast-serve-helpers/node_modules/css-loader": {
@@ -28562,9 +30009,9 @@
       }
     },
     "node_modules/spfx-fast-serve-helpers/node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -29061,6 +30508,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ]
     },
     "node_modules/style-loader": {
       "version": "4.0.0",
@@ -30639,12 +32098,6 @@
         "extsprintf": "^1.2.0"
       }
     },
-    "node_modules/verror/node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "dev": true
-    },
     "node_modules/vinyl": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
@@ -31185,20 +32638,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/webpack-dev-server/node_modules/glob": {

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   },
   "dependencies": {
     "@fluentui/react": "^8.106.4",
-    "@microsoft/sp-component-base": "1.20.0",
-    "@microsoft/sp-core-library": "1.20.0",
-    "@microsoft/sp-lodash-subset": "1.20.0",
-    "@microsoft/sp-office-ui-fabric-core": "1.20.0",
-    "@microsoft/sp-property-pane": "1.20.0",
-    "@microsoft/sp-webpart-base": "1.20.0",
+    "@microsoft/sp-component-base": "1.21.0-beta.0",
+    "@microsoft/sp-core-library": "1.21.0-beta.0",
+    "@microsoft/sp-lodash-subset": "1.21.0-beta.0",
+    "@microsoft/sp-office-ui-fabric-core": "1.21.0-beta.0",
+    "@microsoft/sp-property-pane": "1.21.0-beta.0",
+    "@microsoft/sp-webpart-base": "1.21.0-beta.0",
     "@pnp/graph": "^4.10.0",
     "@pnp/sp": "^4.10.0",
     "react": "17.0.1",
@@ -27,11 +27,11 @@
     "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@microsoft/eslint-config-spfx": "1.20.2",
-    "@microsoft/eslint-plugin-spfx": "1.20.2",
+    "@microsoft/eslint-config-spfx": "1.21.0-beta.0",
+    "@microsoft/eslint-plugin-spfx": "1.21.0-beta.0",
     "@microsoft/rush-stack-compiler-4.7": "0.1.0",
-    "@microsoft/sp-build-web": "1.20.2",
-    "@microsoft/sp-module-interfaces": "1.20.2",
+    "@microsoft/sp-build-web": "1.21.0-beta.0",
+    "@microsoft/sp-module-interfaces": "1.21.0-beta.0",
     "@rushstack/eslint-config": "4.0.1",
     "@types/react": "17.0.45",
     "@types/react-dom": "17.0.17",
@@ -40,7 +40,7 @@
     "eslint": "8.57.0",
     "eslint-plugin-react-hooks": "4.3.0",
     "gulp": "4.0.2",
-    "typescript": "4.7.4",
-    "spfx-fast-serve-helpers": "~1.20.0"
+    "spfx-fast-serve-helpers": "~1.20.0",
+    "typescript": "4.7.4"
   }
 }


### PR DESCRIPTION
Upgraded the project to SPFx v1.21.0. Closes #10

Note : follow these steps to serve the project. 

```
npm install 
spfx-fast-serve
```

this updates to latest version of spfx-fast-serve-helpers to ~1.21.0-beta.0, which isnt available yet. so, skip the below step 

```
ℹ Now install dependencies ('npm install') and execute 'npm run serve' afterwards.
```
-false the below option
```
√ Do you want to install the dependencies now? ("Enter" to install, "Esc" to finish without installing) (Y/n) · false

npm run serve
```

Thanks,
Nish